### PR TITLE
Bump fluent to 0.11 to align with Vapor 0.18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "FluentMongo",
     dependencies: [
-    	.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 0, minor: 10),
+    	.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 0, minor: 11),
     	.Package(url: "https://github.com/OpenKitten/MongoKitten.git", majorVersion: 1, minor: 6)
     ]
 )


### PR DESCRIPTION
New to Package Manager but seems like the Fluent version needs to match the current version used by Vapor 18, which is 0.11 
