### PR TITLE
added support for boolean types

### DIFF
--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -28,6 +28,8 @@ extension BSON.Value {
             return .object(dictOfNodes)
         case .binary(_, let data):
             return .bytes(data)
+        case .boolean(let bool): 
+            return .bool(bool)
         default:
             print("[FluentMongo] Could not convert BSON to Node: \(self)")
             return .null


### PR DESCRIPTION
Currently using boolean within a mongo document will result in the following error `[FluentMongo] Could not convert BSON to Node: boolean(true)`

The proposed change will sufficiently support the conversion from a BSON type to Boolean
