### PR TITLE
provide warning to those wishing to use siblings

### DIFF
--- a/Sources/Query+MongoKitten.swift
+++ b/Sources/Query+MongoKitten.swift
@@ -7,7 +7,7 @@ extension Fluent.Query {
             return nil
         }
         
-        guard query.unions.count != 0 else {
+        guard unions.count != 0 else {
             fatalError("UNION CURRENTLY NOT SUPPORTED: SEE https://github.com/vapor/mongo-driver/issues/13")
         }
         

--- a/Sources/Query+MongoKitten.swift
+++ b/Sources/Query+MongoKitten.swift
@@ -7,7 +7,7 @@ extension Fluent.Query {
             return nil
         }
         
-        guard query.unions != 0 else {
+        guard query.unions.count != 0 else {
             fatalError("UNION CURRENTLY NOT SUPPORTED: SEE https://github.com/vapor/mongo-driver/issues/13")
         }
         

--- a/Sources/Query+MongoKitten.swift
+++ b/Sources/Query+MongoKitten.swift
@@ -6,7 +6,11 @@ extension Fluent.Query {
         guard filters.count != 0 else {
             return nil
         }
-
+        
+        guard query.unions != 0 else {
+            fatalError("UNION CURRENTLY NOT SUPPORTED: SEE https://github.com/vapor/mongo-driver/issues/13")
+        }
+        
         var query: MongoKitten.Query?
 
         for filter in filters {


### PR DESCRIPTION
siblings within fluent, require unions to be implemented in mongo driver
