### PR TITLE
the primary key of new row was `null`; skip the `idKey` when update

### DIFF
--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -97,6 +97,9 @@ public class MongoDriver: Fluent.Driver {
         var document: Document = [:]
         
         for (key, val) in data {
+            if key == idKey && val == .null {
+                continue
+            }
             document[key] = val.bson
         }
         
@@ -127,6 +130,9 @@ public class MongoDriver: Fluent.Driver {
         var document: Document = [:]
 
         for (key, val) in data {
+            if key == idKey {
+                continue
+            }
             document[key] = val.bson
         }
 

--- a/Tests/FluentMongoTests/DriverTests.swift
+++ b/Tests/FluentMongoTests/DriverTests.swift
@@ -43,6 +43,10 @@ class DriverTests: XCTestCase {
         } catch {
             XCTFail("Could not save: \(error)")
         }
+        
+        if user.id == .null {
+            XCTFail("Primary key was null")
+        }
         return user
     }
 


### PR DESCRIPTION
- the primary key of new row was `null` 
  when we create a new row like 
  
  ``` swift
  var user = User(id: nil, name: "Vapor", email: "mongo@vapor.codes")
  try user.save()
  ```
  
  the `user.id` will be  `null`. 
  skip the `_id` and the `MongoKitten` will fill this key automatically.
- An Exception was raise when update
  
  ```
  "exception" : "The _id field cannot be changed from {_id: ObjectId('5bc5f5570b6ecc7bf24d738b')} to {_id: \"5bc5f5570b6ecc7bf24d738b\"}.",
  ```
  
  In most cases, we will not modify the primary key, so skip it too.
