### PR TITLE
Implements count functionality to queries

### DIFF
--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -42,6 +42,8 @@ public class MongoDriver: Fluent.Driver {
                 items.append(i)
             }
             return try items.makeNode()
+        case .count:
+            return try count(query).makeNode()
         case .create:
             let document = try insert(query)
             if let documentId = getId(document: document) {
@@ -116,6 +118,13 @@ public class MongoDriver: Fluent.Driver {
         }
 
         return cursor
+    }
+    
+    private func count<T: Entity>(_ query: Fluent.Query<T>) throws -> Int {
+        if let q = query.mongoKittenQuery {
+            return try database[query.entity].count(matching: q)
+        }
+        return try database[query.entity].count()
     }
 
     private func modify<T: Entity>(_ query: Fluent.Query<T>) throws {


### PR DESCRIPTION
This is part of a series of pull requests to implement the count functionality for queries in Fluent. This addition allows to quickly determine the number of results of a query, without retrieving and parsing any data from the database.

There is also a pull request for Fluent (vapor/fluent#115).
