### PR TITLE
Added support to Int32 on BSON conversion to Node - Gabriel Araujo

### DIFF
--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -6,6 +6,8 @@ extension BSON.Value {
         switch self {
         case .double(let double):
             return .number(.double(double))
+        case .int32(let int):
+            return .number(.int(Int(int)))
         case .int64(let int):
             return .number(.int(Int(int)))
         case .string(let string):


### PR DESCRIPTION
Hello,

I added the support for Int32 because when I was configuring a test project I had some documents with int32 attributes..
So when I was trying to list them the int32 was not displaying and I was receiving the error "[FluentMongo] Could not convert BSON to Node: Int32"

After I added the case for Int32 the app started to display the number and the console no longer prompted the error message..

I think this change is needed because the framework can not limit the types the DB can have..

Thank You