### PR TITLE
Fixed a segmentation fault crash on Linux

### DIFF
--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -33,7 +33,7 @@ extension BSON.Value {
         case .boolean(let bool): 
             return .bool(bool)
         default:
-            print("[FluentMongo] Could not convert BSON to Node: \(self)")
+            print("[FluentMongo] Could not convert BSON to Node.")
             return .null
         }
     }


### PR DESCRIPTION
This PR fixes a segmentation fault that is crushing the app when calling a `description` function on `Foundation.Date` object for the second time (https://bugs.swift.org/browse/SR-2485).

Since `BSON.Value.dateTime` is still unsupported, we will try to print error message about unsupported enum case, which prints associated `date`, which causes a segmentation fault.

The "actual" bug is in deed not in the MongoDriver, but before Apple fixes SR-2485, we cannot print descriptions of Date on Linux more then once ;)