### PR TITLE
Adding support for limits and sorting

### DIFF
--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -129,13 +129,23 @@ public class MongoDriver: Fluent.Driver {
 
         let aqt = try query.makeAQT()
         let mkq = MKQuery(aqt: aqt)
+        let sortDocument: Document?
+        
+        if !query.sorts.isEmpty {
+            let elements = query.sorts.map { ($0.field, $0.direction == .ascending ? Value.int32(1) : Value.int32(-1)) }
+            sortDocument = Document(dictionaryElements: elements)
+        } else {
+            sortDocument = nil
+        }
         
         if let limit = query.limit {
             cursor = try database[query.entity].find(matching: mkq,
+                                                     sortedBy: sortDocument,
                                                      skipping: Int32(limit.offset),
                                                      limitedTo: Int32(limit.count))
         } else {
-            cursor = try database[query.entity].find(matching: mkq)
+            cursor = try database[query.entity].find(matching: mkq,
+                                                     sortedBy: sortDocument)
         }
 
         return cursor

--- a/Tests/FluentMongoTests/DriverTests.swift
+++ b/Tests/FluentMongoTests/DriverTests.swift
@@ -17,6 +17,7 @@ class DriverTests: XCTestCase {
         return [
             ("testConnectFailing", testConnectFailing),
             ("testSaveClearFind", testSaveClearFind),
+            ("testModify", testModify)
         ]
     }
     

--- a/Tests/FluentMongoTests/DriverTests.swift
+++ b/Tests/FluentMongoTests/DriverTests.swift
@@ -9,7 +9,7 @@ import Fluent
  
     - user: test
     - password: test
-    - localhost: test
+    - host: localhost
     - port: 27017
 */
 class DriverTests: XCTestCase {


### PR DESCRIPTION
This PR resolves #24 by handling the Query limit and sorts fields inside MongoDriver.

For `select` queries:
- The `Query.sorts` array is used to build a _sort document_ in the following format: `{ "field1": 1, "field2": -1, ... }` (depending on sort order), and passed to MongoKitten's `find` method.
- If `Query.limit` is set, the count and offset parameters are passed directly to MK `find`.

For `delete` commands:
- If no filters are set and limit is 0 or not set, the whole collection is dropped (previous behavior).
- If there are filters and the limit is 0 or not set, every matching document is removed (again, previous behavior)
- If the limit is 1, a single matching document is removed.
- Every other limit value is considered invalid and an error is thrown before calling MK. (This is to comply with the delete command's specification, which only allows these two values – and would fail on the driver level anyway.)