### PR TITLE
Update to MongoKitten 3 and support latest fluent count() feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "FluentMongo",
     dependencies: [
     	.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1),
-    	.Package(url: "https://github.com/OpenKitten/MongoKitten.git", majorVersion: 1, minor: 7)
+    	.Package(url: "https://github.com/OpenKitten/MongoKitten.git", "3.0.0-beta")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "FluentMongo",
     dependencies: [
     	.Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1),
-    	.Package(url: "https://github.com/OpenKitten/MongoKitten.git", "3.0.0-beta")
+    	.Package(url: "https://github.com/OpenKitten/MongoKitten.git", majorVersion: 3)
     ]
 )

--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -1,39 +1,75 @@
+import BSON
 import MongoKitten
 import Fluent
 
-extension BSON.Value {
+//extension BSON.Value {
+//    var node: Node {
+//        switch self {
+//        case .double(let double):
+//            return .number(.double(double))
+//        case .int32(let int):
+//            return .number(.int(Int(int)))
+//        case .int64(let int):
+//            return .number(.int(Int(int)))
+//        case .string(let string):
+//            return .string(string)
+//        case .objectId(let objId):
+//            return .string(objId.hexString)
+//        case .null:
+//            return .null
+//        case .array(let doc):
+//            var arrayOfNodes: [Node] = []
+//            for (_, val) in doc {
+//                arrayOfNodes.append(val.node)
+//            }
+//            return .array(arrayOfNodes)
+//        case .document(let doc):
+//            var dictOfNodes: [String : Node] = [:]
+//            for (key, val) in doc {
+//                dictOfNodes[key] = val.node
+//            }
+//            return .object(dictOfNodes)
+//        case .binary(_, let data):
+//            return .bytes(data)
+//        case .boolean(let bool): 
+//            return .bool(bool)
+//        default:
+//            print("[FluentMongo] Could not convert BSON to Node.")
+//            return .null
+//        }
+//    }
+//}
+
+extension ValueConvertible {
     var node: Node {
-        switch self {
-        case .double(let double):
-            return .number(.double(double))
-        case .int32(let int):
-            return .number(.int(Int(int)))
-        case .int64(let int):
-            return .number(.int(Int(int)))
-        case .string(let string):
-            return .string(string)
-        case .objectId(let objId):
-            return .string(objId.hexString)
-        case .null:
-            return .null
-        case .array(let doc):
-            var arrayOfNodes: [Node] = []
-            for (_, val) in doc {
-                arrayOfNodes.append(val.node)
+        let value = self.makeBSONPrimitive()
+        
+        switch value {
+        case is Double:
+            return .number(.double(self as! Double))
+        case is Int, is Int32, is Int64:
+            return .number(.int(value.int!))
+        case is String:
+            return .string(value as! String)
+        case is ObjectId:
+            return .string((value as! ObjectId).hexString)
+        case is Binary:
+            return .bytes((value as! Binary).makeBytes())
+        case is Document:
+            let document = (value as! Document)
+
+            if document.validatesAsArray() {
+                return .array(document.arrayValue.map { $0.node })
+            } else {
+                var dictOfNodes: [String : Node] = [:]
+                
+                for (key, val) in document {
+                    dictOfNodes[key] = val.node
+                }
+                
+                return .object(dictOfNodes)
             }
-            return .array(arrayOfNodes)
-        case .document(let doc):
-            var dictOfNodes: [String : Node] = [:]
-            for (key, val) in doc {
-                dictOfNodes[key] = val.node
-            }
-            return .object(dictOfNodes)
-        case .binary(_, let data):
-            return .bytes(data)
-        case .boolean(let bool): 
-            return .bool(bool)
         default:
-            print("[FluentMongo] Could not convert BSON to Node.")
             return .null
         }
     }

--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -40,7 +40,7 @@ import Fluent
 //    }
 //}
 
-extension ValueConvertible {
+public extension ValueConvertible {
     var node: Node {
         let value = self.makeBSONPrimitive()
         

--- a/Sources/BSON+StructuredData.swift
+++ b/Sources/BSON+StructuredData.swift
@@ -2,44 +2,6 @@ import BSON
 import MongoKitten
 import Fluent
 
-//extension BSON.Value {
-//    var node: Node {
-//        switch self {
-//        case .double(let double):
-//            return .number(.double(double))
-//        case .int32(let int):
-//            return .number(.int(Int(int)))
-//        case .int64(let int):
-//            return .number(.int(Int(int)))
-//        case .string(let string):
-//            return .string(string)
-//        case .objectId(let objId):
-//            return .string(objId.hexString)
-//        case .null:
-//            return .null
-//        case .array(let doc):
-//            var arrayOfNodes: [Node] = []
-//            for (_, val) in doc {
-//                arrayOfNodes.append(val.node)
-//            }
-//            return .array(arrayOfNodes)
-//        case .document(let doc):
-//            var dictOfNodes: [String : Node] = [:]
-//            for (key, val) in doc {
-//                dictOfNodes[key] = val.node
-//            }
-//            return .object(dictOfNodes)
-//        case .binary(_, let data):
-//            return .bytes(data)
-//        case .boolean(let bool): 
-//            return .bool(bool)
-//        default:
-//            print("[FluentMongo] Could not convert BSON to Node.")
-//            return .null
-//        }
-//    }
-//}
-
 public extension ValueConvertible {
     var node: Node {
         let value = self.makeBSONPrimitive()
@@ -69,6 +31,8 @@ public extension ValueConvertible {
                 
                 return .object(dictOfNodes)
             }
+        case is Bool:
+            return .bool(value.boolValue!)
         default:
             return .null
         }

--- a/Sources/Filter+MongoKitten.swift
+++ b/Sources/Filter+MongoKitten.swift
@@ -2,35 +2,34 @@ import MongoKitten
 import Fluent
 
 extension Fluent.Filter {
-    public func makeAQT() throws -> MongoKitten.AQT {
-        let query: MongoKitten.AQT
+    public func makeMKQuery() -> MongoKitten.Query {
+        let query: MongoKitten.Query
 
         switch self.method {
         case .compare(let key, let comparison, let val):
             switch comparison {
             case .equals:
-                if let objId = try? ObjectId(val.bson.string), key == "_id" {
-                    let value = Value.objectId(objId)
-                    query = .valEquals(key: key, val: value)
+                if key == "_id", let id = try? ObjectId(val.string ?? "") {
+                    query = "_id" == id
                 } else {
-                    query = .valEquals(key: key, val: val.bson)
+                    query = key == val
                 }
             case .greaterThan:
-                query = .greaterThan(key: key, val: val.bson)
+                query = key > val
             case .lessThan:
-                query = .smallerThan(key: key, val: val.bson)
+                query = key < val
             case .greaterThanOrEquals:
-                query = .greaterThanOrEqual(key: key, val: val.bson)
+                query = key >= val
             case .lessThanOrEquals:
-                query = .smallerThanOrEqual(key: key, val: val.bson)
+                query = key <= val
             case .notEquals:
-                query = .valNotEquals(key: key, val: val.bson)
+                query = key != val
             case .contains:
-                query = .contains(key: key, val: val.bson.string)
+                query = MKQuery(aqt: .contains(key: key, val: val.string ?? "", options: []))
             case .hasPrefix:
-                query = .startsWith(key: key, val: val.bson.string)
+                query = MKQuery(aqt: .startsWith(key: key, val: val.string ?? ""))
             case .hasSuffix:
-                query = .endsWith(key: key, val: val.bson.string)
+                query = MKQuery(aqt: .endsWith(key: key, val: val.string ?? ""))
             }
         case .subset(let key, let scope, let values):
             switch scope {
@@ -38,28 +37,29 @@ extension Fluent.Filter {
                 var ors: [AQT] = []
 
                 for val in values {
-                    ors.append(.valEquals(key: key, val: val.bson))
+                    ors.append(.valEquals(key: key, val: val))
                 }
 
-                query = .or(ors)
+                query = MKQuery(aqt: .or(ors))
             case .notIn:
                 var ands: [AQT] = []
 
                 for val in values {
-                    ands.append(.valNotEquals(key: key, val: val.bson))
+                    ands.append(.valNotEquals(key: key, val: val))
                 }
 
-                query = .and(ands)
+                query = MKQuery(aqt: .and(ands))
             }
         case .group(let relation, let filters):
-            let aqts = try filters.map { try $0.makeAQT() }
-
-            switch relation {
-            case .and:
-                query = .and(aqts)
-            case .or:
-                query = .or(aqts)
-            }
+            fatalError()
+//            let aqts = try filters.reduce(Query([:]), &&)
+//
+//            switch relation {
+//            case .and:
+//                query = MKQuery(aqt: .and(aqts))
+//            case .or:
+//                query = MKQuery(aqt: .or(aqts))
+//            }
         }
         
         return query

--- a/Sources/Filter+MongoKitten.swift
+++ b/Sources/Filter+MongoKitten.swift
@@ -51,15 +51,14 @@ extension Fluent.Filter {
                 query = MKQuery(aqt: .and(ands))
             }
         case .group(let relation, let filters):
-            fatalError()
-//            let aqts = try filters.reduce(Query([:]), &&)
-//
-//            switch relation {
-//            case .and:
-//                query = MKQuery(aqt: .and(aqts))
-//            case .or:
-//                query = MKQuery(aqt: .or(aqts))
-//            }
+            query = filters.map {
+                $0.makeMKQuery()
+                }.reduce(Query([:]), { lhs, rhs in
+                    switch relation {
+                    case .and: return lhs && rhs
+                    case .or: return lhs || rhs
+                    }
+                })
         }
         
         return query

--- a/Sources/Filter+MongoKitten.swift
+++ b/Sources/Filter+MongoKitten.swift
@@ -23,7 +23,11 @@ extension Fluent.Filter {
             case .lessThanOrEquals:
                 query = key <= val
             case .notEquals:
-                query = key != val
+                if key == "_id", let id = try? ObjectId(val.string ?? "") {
+                    query = "_id" != id
+                } else {
+                    query = key != val
+                }
             case .contains:
                 query = MKQuery(aqt: .contains(key: key, val: val.string ?? "", options: []))
             case .hasPrefix:

--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -54,6 +54,8 @@ public class MongoDriver: Fluent.Driver {
             } else {
                 return Node.null
             }
+        case .count:
+            return try count(query).node
         }
     }
     
@@ -112,6 +114,22 @@ public class MongoDriver: Fluent.Driver {
         return try database[query.entity].insert(document)
     }
 
+    private func count<T: Entity>(_ query: Fluent.Query<T>) throws -> Int {
+        let count: Int
+        
+        let mkq = try query.makeMKQuery()
+        
+        if let limit = query.limit {
+            count = try database[query.entity].count(matching: mkq,
+                                                     limitedTo: Int32(limit.count),
+                                                     skipping: Int32(limit.offset))
+        } else {
+            count = try database[query.entity].count(matching: mkq)
+        }
+        
+        return count
+    }
+    
     private func select<T: Entity>(_ query: Fluent.Query<T>) throws -> Cursor<Document> {
         let cursor: Cursor<Document>
 

--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -139,7 +139,7 @@ public class MongoDriver: Fluent.Driver {
         let sortDocument: MongoKitten.Sort?
         
         if !query.sorts.isEmpty {
-            let elements = query.sorts.map { sort -> (String, ValueConvertible?) in
+            let elements = query.sorts.map { sort -> (StringVariant, ValueConvertible?) in
                 (sort.field, sort.direction == .ascending ? SortOrder.ascending : SortOrder.descending)
             }
             sortDocument = MongoKitten.Sort(Document(dictionaryElements: elements))

--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -49,7 +49,11 @@ public class MongoDriver: Fluent.Driver {
             return Node.null
         case .modify:
             try modify(query)
-            return query.data ?? Node.null
+            if let data = query.data {
+                return [data]
+            } else {
+                return Node.null
+            }
         }
     }
     

--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -55,7 +55,7 @@ public class MongoDriver: Fluent.Driver {
                 return Node.null
             }
         case .count:
-            return try count(query).node
+            return try count(query).makeNode()
         }
     }
     

--- a/Sources/Query+MongoKitten.swift
+++ b/Sources/Query+MongoKitten.swift
@@ -2,17 +2,17 @@ import MongoKitten
 import Fluent
 
 extension Fluent.Query {
-    func makeAQT() throws -> MongoKitten.AQT {
+    func makeMKQuery() throws -> MongoKitten.Query {
         if unions.count != 0 {
             fatalError("[Mongo] Unions not yet supported. Use nesting instead.")
         }
 
-        let aqts = try filters.map { try $0.makeAQT() }
+        let query = filters.map {
+            $0.makeMKQuery()
+        }.reduce(Query([:]), { lhs, rhs in
+            return lhs && rhs
+        })
 
-        if aqts.isEmpty {
-            return .nothing
-        }
-
-        return .and(aqts)
+        return query
     }
 }

--- a/Sources/Query+MongoKitten.swift
+++ b/Sources/Query+MongoKitten.swift
@@ -6,13 +6,15 @@ extension Fluent.Query {
         if unions.count != 0 {
             fatalError("[Mongo] Unions not yet supported. Use nesting instead.")
         }
-
-        let query = filters.map {
-            $0.makeMKQuery()
-        }.reduce(Query([:]), { lhs, rhs in
-            return lhs && rhs
-        })
-
-        return query
+        
+        switch filters.count {
+        case 0: return Query([:])
+        case 1: return try filters[0].makeMKQuery()
+        default:
+            let queries = try filters.map {
+                try $0.makeMKQuery()
+            }
+            return queries.dropFirst().reduce(queries[0], &&)
+        }
     }
 }

--- a/Sources/StructuredData+BSON.swift
+++ b/Sources/StructuredData+BSON.swift
@@ -2,38 +2,36 @@ import MongoKitten
 import Fluent
 import Node
 
-extension Node {
-    var bson: BSON.Value {
+extension Node: ValueConvertible {
+    public func makeBSONPrimitive() -> BSONPrimitive {
         switch self {
         case .number(let num):
             switch num {
             case .int(let int):
-                return .int64(Int64(int))
-            case .double(let dbl):
-                return .double(dbl)
+                return Int64(int)
+            case .double(let double):
+                return double
             case .uint(let uint):
-                return .int64(Int64(uint))
+                return Int64(uint)
             }
         case .array(let array):
-            let bsonArray = array.map { item in
-                return item.bson
-            }
-            let document = Document(array: bsonArray)
-            return .array(document)
+            return Document(array: array)
         case .bool(let bool):
-            return .boolean(bool)
+            return bool
         case .object(let dict):
-            var bsonDict: Document = [:]
-            dict.forEach { key, val in
-                bsonDict[key] = val.bson
+            var document: Document = [:]
+
+            for (key, value) in dict {
+                document[raw: key] = value
             }
-            return .document(bsonDict)
+            
+            return document
         case .null:
-            return .null
+            return Null()
         case .string(let string):
-            return .string(string)
-        case .bytes(let byteArray):
-            return .binary(subtype: .generic, data: byteArray)
+            return string
+        case .bytes(let data):
+            return Binary(data: data, withSubtype: .generic)
         }
     }
 }

--- a/Tests/FluentMongoTests/DriverTests.swift
+++ b/Tests/FluentMongoTests/DriverTests.swift
@@ -52,7 +52,7 @@ class DriverTests: XCTestCase {
 
     func testConnectFailing() {
         do {
-            let _ = try MongoDriver(database: "test", user: "test", password: "test", host: "localhost", port: 500)
+            let _ = try MongoDriver(connectionString: "mongodb://test:test@localhost:500/test")
             XCTFail("Should not connect.")
         } catch {
             // This should fail.

--- a/Tests/FluentMongoTests/DriverTests.swift
+++ b/Tests/FluentMongoTests/DriverTests.swift
@@ -23,7 +23,10 @@ class DriverTests: XCTestCase {
             ("testDeleteLimit0Implicit", testDeleteLimit0Implicit),
             ("testDeleteLimit0Explicit", testDeleteLimit0Explicit),
             ("testDeleteLimit1", testDeleteLimit1),
-            ("testDeleteLimitInvalid", testDeleteLimitInvalid)
+            ("testDeleteLimitInvalid", testDeleteLimitInvalid),
+            ("testCount", testCount),
+            ("testGroupOr", testGroupOr),
+            ("testGroupAnd", testGroupAnd),
         ]
     }
     
@@ -220,5 +223,61 @@ class DriverTests: XCTestCase {
         } catch {
             // this should fail
         }
+    }
+    
+    func testCount() throws {
+        // Insert dummy users Vapor0, Vapor1, Vapor0, ..., Vapor1
+        for i in (0..<10) {
+            _ = createUser(suffix: "\(i%2)")
+        }
+        let count = try User.query().count()
+        XCTAssertEqual(10, count)
+    }
+    
+    func testGroupOr() throws {
+        // Insert dummy users Vapor0, Vapor1, ...
+        for i in (0..<10) {
+            _ = createUser(suffix: "\(i)")
+        }
+        
+        let query = try User.query().or({ query in
+            try query.filter("name", "Vapor3")
+            try query.filter("name", "Vapor4")
+            try query.filter("name", "Vapor5")
+            try query.filter("name", "Vapor6")
+            try query.filter("name", "Vapor7")
+        })
+        query.limit = Limit(count: 3, offset: 1)
+        let result = try query.all()
+        XCTAssertEqual(["Vapor4", "Vapor5", "Vapor6"], result.map { $0.name })
+    }
+    
+    func testGroupAnd() throws {
+        // Insert dummy users Vapor0, Vapor1, ...
+        for i in (0..<10) {
+            var user = createUser(suffix: "\(i)")
+            if i%2 == 0 {
+                user.email = "test@test.com"
+                try user.save()
+            }
+        }
+        
+        let query = try User.query()
+            .or{ query in
+                try query.filter("name", "Vapor1")
+                try query.and{ query in
+                    try query.filter("name", "Vapor2")
+                    try query.filter("email", "test@test.com")
+                }
+                try query.and{ query in
+                    try query.filter("name", "Vapor3")
+                    try query.filter("email", "test@test.com")
+                }
+                try query.filter("name", "Vapor4")
+                try query.filter("name", "Vapor5")
+            }
+        query.limit = Limit(count: 2, offset: 1)
+        let result = try query.all()
+        XCTAssertEqual(["Vapor2", "Vapor4"], result.map { $0.name })
     }
 }

--- a/Tests/FluentMongoTests/Utilities/MongoDriver+Tests.swift
+++ b/Tests/FluentMongoTests/Utilities/MongoDriver+Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 extension MongoDriver {
     static func makeTestConnection() -> MongoDriver {
         do {
-            return try MongoDriver(database: "test", user: "test", password: "test", host: "127.0.0.1", port: 27017)
+            return try MongoDriver(connectionString: "mongodb://test:test@127.0.0.1:27017/test")
         } catch {
             print()
             print()


### PR DESCRIPTION
I built this on top of @Joannis #26  by updating to the official mongokitten 3 release and fixing some other issues (e.g. missing bson to bool conversion).
I also added support for the count() feature recently added to fluent. 
Finally the underlying mongokitten driver is now public so that users are able to use it directly for implementing features currently not available on fluent (e.g. geoqueries and indexes).  