### PR TITLE
Add support for subset queries

### DIFF
--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -114,9 +114,13 @@ extension MongoKitten.Database : Fluent.Driver, Connection {
                 } else {
                     subQuery = try makeQuery(filters, method: .or)
                 }
-            case .subset(_, _, _):
-                // TODO:
-                throw Error.unsupported
+            case .subset(let key, let scope, let values):
+                switch scope {
+                case .in:
+                    subQuery = MKQuery(aqt: AQT.in(key: key, in: values))
+                case .notIn:
+                    subQuery = MKQuery(aqt: AQT.not(AQT.in(key: key, in: values)))
+                }
             }
             
             if query.makeDocument().count == 0  {

--- a/Tests/MongoDriverTests/DriverTests.swift
+++ b/Tests/MongoDriverTests/DriverTests.swift
@@ -13,6 +13,7 @@ class DriverTests: XCTestCase {
             ("testTimestamps", testTimestamps),
             ("testSoftDelete", testSoftDelete),
             ("testIndex", testIndex),
+            ("testSubset", testSubset),
         ]
     }
     
@@ -65,5 +66,12 @@ class DriverTests: XCTestCase {
         let db = Fluent.Database(driver)
         let tester = Tester(database: db)
         try tester.testIndex()
+    }
+
+    func testSubset() throws {
+        try driver.drop()
+        let db = Fluent.Database(driver)
+        let tester = Tester(database: db)
+        try tester.testSubset()
     }
 }

--- a/Tests/MongoDriverTests/Tester+Subset.swift
+++ b/Tests/MongoDriverTests/Tester+Subset.swift
@@ -1,0 +1,27 @@
+import FluentTester
+
+extension Tester {
+    public func testSubset() throws {
+        Compound.database = database
+        try Compound.prepare(database)
+        defer {
+            try! Compound.revert(database)
+        }
+
+        var compounds: [Compound] = []
+        for i in 0..<4 {
+            let compound = Compound(name: "Test \(i)")
+            try compound.save()
+            compounds.append(compound)
+        }
+
+        let firstTwoCompounds = Array(compounds[0..<2])
+        let firstTwoNames = firstTwoCompounds.map { $0.name.makeNode() }
+
+        let inQuery = try Compound.makeQuery().filter(.subset("name", .in, firstTwoNames))
+        try testEquals(firstTwoCompounds, try inQuery.all())
+
+        let notInQuery = try Compound.makeQuery().filter(.subset("name", .notIn, firstTwoNames))
+        try testEquals(Array(compounds[2..<4]), try notInQuery.all())
+    }
+}


### PR DESCRIPTION
This adds support for subset queries, i.e.:

```
query.filter(.subset("_id", .in, ids))
```
and
```
query.filter(.subset("_id", .notIn, ids))
```