### PR TITLE
[FIX] (makeDocument) Saving arrays on fluent models failing

### DIFF
--- a/Sources/Conversion.swift
+++ b/Sources/Conversion.swift
@@ -24,7 +24,7 @@ extension Primitive {
             return .array(array.map { $0.makeNode() })
         case let document as Document:
             if document.validatesAsArray() {
-                return .array(document.arrayValue.map { $0.makeNode() })
+                return .array(document.arrayRepresentation.map { $0.makeNode() })
             } else {
                 let object = document.map({ [$0.0: $0.1.makeNode()] as [String: Node] }).reduce([:]) { lhs, rhs in
                     var lhs = lhs

--- a/Sources/MongoDriver.swift
+++ b/Sources/MongoDriver.swift
@@ -171,7 +171,13 @@ extension MongoKitten.Database : Fluent.Driver, Connection {
                 throw Error.invalidData
             }
             
-            document[key] = value
+            // Arrays need to be converted to documents first
+            if let arrayValue = value.array {
+                document[key] = Document(array: arrayValue)
+            } else {
+                document[key] = value
+            }
+            
         }
         
         if let key = document.type(at: "_id"), case ElementType.nullValue = key {

--- a/Tests/MongoDriverTests/DriverTests.swift
+++ b/Tests/MongoDriverTests/DriverTests.swift
@@ -7,12 +7,13 @@ class DriverTests: XCTestCase {
     static var allTests : [(String, (DriverTests) -> () throws -> Void)] {
         return [
             ("testInsertAndFind", testInsertAndFind),
+            ("testArray", testArray),
             ("testPivotsAndRelations", testPivotsAndRelations),
             ("testSchema", testSchema),
             ("testPaginate", testPaginate),
             ("testTimestamps", testTimestamps),
             ("testSoftDelete", testSoftDelete),
-            ("testIndex", testIndex),
+            ("testIndex", testIndex)
         ]
     }
     
@@ -23,6 +24,34 @@ class DriverTests: XCTestCase {
         let db = Fluent.Database(driver)
         let tester = Tester(database: db)
         try tester.testInsertAndFind()
+    }
+    
+    // This test is for Mongo specific functionality.
+    // It tests the ability to embed an array of documents in a document.
+    func testArray() throws {
+        try driver.drop()
+        let db = Fluent.Database(driver)
+        
+        RecordStore.database = db
+        
+        let recordStore = RecordStore(
+            vinyls: [
+                Vinyl(name: "Thriller", year: 1982),
+                Vinyl(name: "Back in Black", year: 1980),
+                Vinyl(name: "The Dark Side of the Moon", year: 1973)
+            ]
+        )
+
+        try recordStore.save()
+        
+        guard
+            let foundStore = try RecordStore.makeQuery().all().first else {
+                XCTFail()
+                return
+        }
+        
+        XCTAssert(foundStore.vinyls.count == 3)
+        XCTAssert(foundStore.vinyls.filter({ return $0.name == "Thriller" }).count == 1)
     }
     
     func testPivotsAndRelations() throws {

--- a/Tests/MongoDriverTests/RecordStore.swift
+++ b/Tests/MongoDriverTests/RecordStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Fluent
+
+public final class RecordStore: Entity {
+    
+    public static let idType: IdentifierType = .uuid
+    public let storage = Storage()
+    public var vinyls: [Vinyl] = []
+    
+    enum Keys: String {
+        case
+            vinyls
+    }
+    
+    public func makeRow() throws -> Row {
+        
+        var row = Row()
+        try row.set(Keys.vinyls.rawValue, vinyls.flatMap { try $0.makeNode(in: nil) })
+        
+        return row
+    }
+    
+    public init(vinyls: [Vinyl]) {
+        self.vinyls = vinyls
+    }
+    
+    public init(row: Row) throws {
+        
+        let vinylNode: Node? = try? row.get(Keys.vinyls.rawValue)
+        
+        vinyls = vinylNode?.array?.flatMap { node -> Vinyl? in
+            
+            guard
+                let name = node[Vinyl.Keys.name.rawValue]?.string,
+                let year = node[Vinyl.Keys.year.rawValue]?.int else {
+                    return nil
+            }
+            
+            return Vinyl(name: name, year: year)
+            
+        } ?? []
+        
+    }
+    
+}

--- a/Tests/MongoDriverTests/Vinyl.swift
+++ b/Tests/MongoDriverTests/Vinyl.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Fluent
+
+public final class Vinyl: NodeRepresentable {
+    
+    public var name: String
+    public var year: Int
+    
+    enum Keys: String {
+        case
+            name,
+            year
+    }
+    
+    public init(name: String, year: Int) {
+        
+        self.name = name
+        self.year = year
+        
+    }
+    
+    public func makeNode(in context: Context?) throws -> Node {
+        
+        return Node.object(
+            [
+                Keys.name.rawValue: name.makeNode(),
+                Keys.year.rawValue: year.makeNode()
+            ]
+        )
+    }
+    
+}


### PR DESCRIPTION
Hi,

I'm unable to save arrays in fluent models with Mongo. I don't know if this is the most appropriate way or place to fix this, however it works.

My failing code inside makeRow is:
`try row.set("list", list)`
where list is `Node` made with `Node.array([Node])`.

Currently saves a blank object, not actually an array, and with no data.

Change:
Checks if it is an array, and converts to document. Saving now successful.